### PR TITLE
Set globstar to expand to all nested subdirectories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ jobs:
     - stage: test
       script:
         - docker pull stain/jena
+        - shopt -s globstar
         - docker run -it --rm -v `pwd`:/rdf stain/jena riot -v --debug --validate --time **/*\.{ttl,rdf}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ jobs:
       script:
         - docker pull stain/jena
         - shopt -s globstar
-        - docker run -it --rm -v `pwd`:/rdf stain/jena riot -v --debug --validate --time **/*\.{ttl,rdf}
+        - docker run -it --rm -v `pwd`:/rdf stain/jena riot -v --debug --validate --time **/*\.ttl


### PR DESCRIPTION
@tngTUDOR Please merge if you are OK with this.

Note that after fixing some syntax errors, we still have a [problem with Travis](https://travis-ci.org/BONSAMURAIS/rdf/builds/514124334). I get the same thing on my local machine - even if the validation command runs fine, it exits with status `1`:

> (arborist) cmutel🚲  rdf-trial ➔ docker run -it --rm -v `pwd`:/rdf stain/jena riot -v --debug --validate --time **/*\.{ttl,rdf}
> activitytype/core/electricity_grid/electricity_grid.ttl :  0.04 sec : 24 Triples : 558.14 per second
> activitytype/exiobase3_3_17/exiobase3_3_17.ttl :  0.06 sec : 328 Triples : 5,754.39 per second
> activitytype/lcia/climatechange/climatechange.ttl :  0.01 sec : 16 Triples : 1,333.33 per second
> flowobject/exiobase3_3_17/exiobase3_3_17.ttl :  0.05 sec : 400 Triples : 8,163.27 per second
> flowobject/lcia/climatechange/climatechange.ttl :  0.01 sec : 16 Triples : 2,000.00 per second
> flowobject/us_epa/us_epa.ttl :  0.01 sec : 234 Triples : 16,714.29 per second
> foaf/foaf.ttl :  0.01 sec : 6 Triples : 1,000.00 per second
> location/exiobase3_3_17/exiobase3_3_17.ttl :  0.01 sec : 98 Triples : 10,888.89 per second
> time/time.ttl :  0.01 sec : 92 Triples : 10,222.22 per second
> unit/unit.ttl :  0.01 sec : 10 Triples : 2,000.00 per second
> **/*.rdf :  (No Output)
> Total :  0.21 sec : 1,224 Triples : 5,746.48 per second
> (arborist) cmutel🚲  rdf-trial ➔ echo $?
> 1

No idea how to solve that, though.